### PR TITLE
Migrate admin CMS from DecapCMS to SveltiaCMS

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -5,10 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Content Manager</title>
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>
-    <!-- Include the script that builds the page and powers Decap CMS -->
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Replace decap-cms CDN script and Netlify Identity Widget with SveltiaCMS drop-in replacement. config.yml is unchanged as the GitHub backend and all collection fields are fully compatible.

https://claude.ai/code/session_01GEQaAhxEs23wSwABZdbduq